### PR TITLE
Résolution du probleme de l'email envoyé plusieurs fois

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -23,6 +23,8 @@ class EventsController < ApplicationController
 
     if @event.save
       @event.guests.create!(user_id: current_user.id, status: "confirmed")
+      url = answer_url(@event.id)
+      UserMailer.ask_for_event(@event, url).deliver
       redirect_to event_path(@event)
     else
       render :new
@@ -43,8 +45,8 @@ class EventsController < ApplicationController
 
   def answer
     @event = Event.find(params[:id])
-    url = answer_url
-    UserMailer.ask_for_event(@event, url).deliver
+    # url = answer_url
+    # UserMailer.ask_for_event(@event, url).deliver
   end
 
   def final


### PR DESCRIPTION
Envoie de l'email lors de la création de l'event et non pas lors de l'ouverture de la page, ce qui évite d'envoyer les mails a chaque chargement.