### PR TITLE
Retrait des connexions Google et FB car plus https

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -20,15 +20,15 @@
     <%= f.button :submit, "S'inscrire", class: "btn bungee btn-primary" %>
   </div>
 
-  <%= link_to user_facebook_omniauth_authorize_path, class:"fb my-2" do %>
-    <i class="fab fa-facebook"></i>
-    <p>S'inscrire avec Facebook</p>
-  <% end %>
+  <%#= link_to user_facebook_omniauth_authorize_path, class:"fb my-2" do %>
+    <!-- <i class="fab fa-facebook"></i>
+    <p>S'inscrire avec Facebook</p> -->
+  <%# end %>
 
-  <%= link_to user_google_oauth2_omniauth_authorize_path, class:"google my-2" do %>
-  <i class="fab fa-google"></i>
-  <p>S'inscrire avec Google</p>
-  <% end %>
+  <%#= link_to user_google_oauth2_omniauth_authorize_path, class:"google my-2" do %>
+  <!-- <i class="fab fa-google"></i>
+  <p>S'inscrire avec Google</p> -->
+  <%# end %>
 <% end %>
 <br>
 <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -16,15 +16,15 @@
     <%= f.button :submit, "Connexion", class: "btn bungee btn-primary" %>
   </div>
 
-  <%= link_to user_facebook_omniauth_authorize_path, class:"fb my-2" do %>
-    <i class="fab fa-facebook"></i>
-    <p>Se connecter avec Facebook</p>
-  <% end %>
+  <%#= link_to user_facebook_omniauth_authorize_path, class:"fb my-2" do %>
+    <!-- <i class="fab fa-facebook"></i>
+    <p>Se connecter avec Facebook</p> -->
+  <%# end %>
 
-  <%= link_to user_google_oauth2_omniauth_authorize_path, class:"google my-2" do %>
-  <i class="fab fa-google"></i>
-  <p>Se connecter avec Google</p>
-  <% end %>
+  <%#= link_to user_google_oauth2_omniauth_authorize_path, class:"google my-2" do %>
+  <!-- <i class="fab fa-google"></i>
+  <p>Se connecter avec Google</p> -->
+  <%# end %>
 <% end %>
 <br>
 <%= render "devise/shared/links" %>


### PR DESCRIPTION
- Boutons FB et Google connect mis en commentaire pour le moment.
- A réactiver si on repasse en https.